### PR TITLE
Explain error codes of Admin Applet Factory Reset

### DIFF
--- a/content/development/protocols/admin.md
+++ b/content/development/protocols/admin.md
@@ -405,7 +405,8 @@ Get current configurations.
 ### 17. Factory Reset
 
 Reset the applets (FIDO key/cert and SN will not be reset).
-Once the command is executed, you must touch within 2 seconds when blinking until it responds with `9000`.
+PIN retries must be used up for reset to begin.
+Once the command is executed, you must **touch within 2 seconds when blinking** until it responds with `9000`.
 
 #### Request
 
@@ -423,6 +424,8 @@ Once the command is executed, you must touch within 2 seconds when blinking unti
 | SW   | Description |
 | ---- | ----------- |
 | 9000 | Success     |
+| 6982 | Not touched when blinking |
+| 6985 | PIN not locked yet |
 
 ### 18. Vendor specific
 


### PR DESCRIPTION
The Factory Reset command returns undocumented error codes. 

Even though the documentation does instruct users to touch when blinking, <del>dumb</del> users <del>like me</del> tend to forget to touch and find the error code confusing. 

Ref: https://github.com/canokeys/canokey-core/blob/ba5e1bf8cbe68c70e34534349ddff80db53da9b3/applets/admin/admin.c#L134-L134