### PR TITLE
guide to managing piv using ykman

### DIFF
--- a/content/userguide/PIV.md
+++ b/content/userguide/PIV.md
@@ -26,7 +26,7 @@ Personal Identity Verification (PIV) is a US government standard defined as [FIP
 
 ## User guide
 
-The following user guide was written with `yubico-piv-tool` version 2.2.1 and `opensc` version 0.22.0 under Linux.
+The following user guide was written with `yubico-piv-tool` version 2.2.1, `ykman` version 4.0.7 and `opensc` version 0.22.0 under Linux.
 
 ### Initial PIV on your card
 
@@ -39,7 +39,11 @@ yubico-piv-tool -r canokeys -a set-chuid
 
 ### Generating keys and certificates
 
-In this example, we are generating a key with NIST P-384 algorithm and name the public key as public384.pem.
+You can either use `yubico-piv-tool` or `ykman`.
+
+#### Using `yubico-piv-tool`
+
+In this example, we are generating a key with NIST P-384 algorithm. The private key is secured in Canokey and the public key will be written into `public384.pem`. 
 
 ```
 $ yubico-piv-tool -r canokeys -s 9a -a generate -A ECCP384 -o public384.pem
@@ -66,6 +70,26 @@ If you want to verify your key is there, you can do so by
 
 ```
 $ yubico-piv-tool -r canokeys -a read-certificate  -s 9a
+```
+
+#### Using `ykman`
+
+This works with `ykman` version 4.0 or above. Similarly, we first generate a new key pair with NIST P-384 algorithm. The public key will be written into `public384.pem`.
+
+```
+$ ykman -r canokeys piv keys generate -a ECCP384 9a public384.pem
+```
+
+Then generate the certificate for that key. The certificate will be store on Canokey, so you don't need to import it again as using `yubico-piv-tool`. We are taking SSH key as an example, and the certificate is valid for 3 years (`-d 1095`).
+
+```
+$ ykman -r canokeys piv certificates generate -d 1095 -s "CN=SSH Key" 9a public384.pem
+```
+
+To verify your certificates on Canokey, you can try
+
+```
+$ ykman -r canokeys piv info
 ```
 
 ### Authentication with SSH
@@ -115,6 +139,21 @@ Enter PIN for 'SSH key':
 X11 forwarding request failed on channel 0
 Last login: Thu Jan 20 22:57:23 2022 from 192.168.1.246
 [user@remote ~]$ 
+```
+
+#### On Windows
+
+To use PIV SSH on Windows, you can try
+
+- [OpenSSH](https://github.com/PowerShell/Win32-OpenSSH) and [OpenSC](https://github.com/OpenSC/OpenSC), and the above instructions will work too. Or
+- [WinCryptSSHAgent](https://github.com/buptczq/WinCryptSSHAgent)
+
+### Importing `.pfx` key&cert
+
+A `.pfx` file may contain both private key and certificate. In this example, we import `credential.pfx` to slot `9d`.
+
+```
+$ yubico-piv-tool -r canokeys -a verify-pin -s 9d -i "credential.pfx" -K PKCS12 -a import-key -a import-cert
 ```
 
 ## Resetting the PIV applet

--- a/content/userguide/PIV.md
+++ b/content/userguide/PIV.md
@@ -148,6 +148,10 @@ To use PIV SSH on Windows, you can try
 - [OpenSSH](https://github.com/PowerShell/Win32-OpenSSH) and [OpenSC](https://github.com/OpenSC/OpenSC), and the above instructions will work too. Or
 - [WinCryptSSHAgent](https://github.com/buptczq/WinCryptSSHAgent)
 
+{{% notice note %}}
+Using PIV SSH on Windows, `NIST P-256` and `NIST P-384` keys are possibly incompatible. If you can't find your public keys with both methods, try `RSA2048` instead. 
+{{% /notice %}}
+
 ### Importing `.pfx` key&cert
 
 A `.pfx` file may contain both private key and certificate. In this example, we import `credential.pfx` to slot `9d`.


### PR DESCRIPTION
... and guide to importing `.pfx` and using piv ssh on windows. 

In addition, 
1. Both the `yubico-piv-tool` and `ykman` work fine on windows.
2. `yubico-piv-tool -r canokeys -a verify-pin -a selfsign-certificate -s 9a -S "/CN=SSH key/" -i public384.pem -o certificate.pem` will generate an error which prompts `Name does not start or does not end with '/'!`, both on linux and windows and with different versions of `yubico-piv-tool`. I dont't know if this is a bug (https://github.com/Yubico/yubico-piv-tool/blob/5a92eb05190d2f8e042b4e27c55620db68ae1f09/common/util.c#L156), but I found two ways out: (1) use `ykman`, as what I've just added to the user guide; (2) adding an extra leading `/` to the subject (`-S "//CN=SSH key/"`), but not verified. 
3. There are some limitations when using PIV SSH on Windows. Having no time for further tests, I just put two assumptions, and at least one of them is right: (1) the certificate must be trusted by Windows, _i.e._, it must be issued from a CA, and cannot be a self-signed one; (2) NIST P-384 is not supported. Use RSA instead. 