### PR TITLE
Touch Policy: use ckman command instead of gpg

### DIFF
--- a/content/userguide/OpenPGP.md
+++ b/content/userguide/OpenPGP.md
@@ -33,7 +33,7 @@ Note that RSA3072 is not supported currently.
 
 ## Touch Policy
 
-There are three key slots for OpenPGP, namely Signature key (SIG), Encryption key (DEC) and Authentication key (AUT). You may turn ON or OFF touch policies for SIG, DEC, AUT in the admin applet in the web console or via the `gpg` command. The value of touch cache time is in between 0 and 255 seconds (0 means no cache).
+There are three key slots for OpenPGP, namely Signature key (SIG), Encryption key (DEC) and Authentication key (AUT). You may turn ON or OFF touch policies for SIG, DEC, AUT in the admin applet in the web console or via the `ckman`(a ykman fork) command. The value of touch cache time is in between 0 and 255 seconds (0 means no cache).
 
 ### Firmware Version <= 1.4
 


### PR DESCRIPTION
I have read the manual, gpg really don't have the ability to change touch policy.  
If you say it can, point it out how to do it!  
This really causes confusion